### PR TITLE
Updated Query to Destructure

### DIFF
--- a/src/init.luau
+++ b/src/init.luau
@@ -222,7 +222,7 @@ function Alecs.RemoveComponent(entity: Entity, component: Component): any
 	return removedData
 end
 
-function Alecs.Query(components: { Component }, strict: boolean?): () -> Entity?
+function Alecs.Query(components: { Component }, strict: boolean?): () -> (Entity, ...any)?
 	local queryBitmask: number = 0
 	for i = 1, #components do
 		queryBitmask = bor(queryBitmask, componentMaskCache[components[i]])
@@ -247,18 +247,22 @@ function Alecs.Query(components: { Component }, strict: boolean?): () -> Entity?
 	local totalArchetypes = #matchingArchetypes
 	local currentArchetypeIndex = 1
 	local currentEntityIndex = 1
-	return function(): Entity?
+	
+	return function(): () -> (Entity, ...any)?
 		while currentArchetypeIndex <= totalArchetypes do
 			local archetype = matchingArchetypes[currentArchetypeIndex]
 			if currentEntityIndex <= archetypeEntityCounts[archetype] then
-				local entity = archetypeEntities[archetype][currentEntityIndex]
+				local entityData = table.create(1, archetypeEntities[archetype][currentEntityIndex])
+				local entity = entityData[1]
+				for _, componentID in components do
+					table.insert(entityData, Alecs.Has(entity, componentID))
+				end
 				currentEntityIndex += 1
-				return entity
+				return table.unpack(entityData)
 			end
-
 			currentArchetypeIndex += 1
 			currentEntityIndex = 1
-		end
+		end		
 		return nil
 	end
 end


### PR DESCRIPTION
Updated Query to de-structure the given components, returns nil if the entity does not have that component set to a value.
You can now do:
`for id, dataOfA, dataOfB, dataOfC in Query({componentA, componentB, componentC}) do`, whereas previously you only received the entity.